### PR TITLE
Prevents "buildLocalFront" command to multiply font resources

### DIFF
--- a/src/main/resources/gulpfile.js
+++ b/src/main/resources/gulpfile.js
@@ -65,7 +65,7 @@ gulp.task('fill-theme', sourceDependency, function () {
 });
 
 gulp.task('version-fonts', ['fill-theme'], function(){
-    var fonts = ['./assets/themes/generic-icons/**/*.woff', './assets/themes/generic-icons/**/*.ttf', './assets/themes/generic-icons/**/*.svg'];
+    var fonts = ['./assets/themes/generic-icons/**/*-icons.{woff,ttf,svg}'];
     return gulp.src(fonts)
         .pipe(rev())
         .pipe(gulp.dest('./assets/themes/generic-icons'))


### PR DESCRIPTION
Quand on utilise régulièrement la commande buildLocalFront, le build multiple rapidement les fichiers de fonts en ajoutant une révision aux fichiers qui ont déjà un numéro de révision.

Avant d'utiliser la commande:
```
ls assets/themes/generic-icons/fonts
generic-icons.svg  generic-icons.ttf  generic-icons.woff
```

Après la première utilisation de la commande:

```
ls assets/themes/generic-icons/fonts
generic-icons-977df786e8.svg  generic-icons-a72e8e843d.woff  generic-icons-bd0221511d.ttf  generic-icons.svg  generic-icons.ttf  generic-icons.woff
```

Après une deuxième utilisation de la commande:

```
ls assets/themes/generic-icons/fonts
generic-icons-977df786e8-977df786e8.svg   generic-icons-a72e8e843d.woff            generic-icons.svg
generic-icons-977df786e8.svg              generic-icons-bd0221511d-bd0221511d.ttf  generic-icons.ttf
generic-icons-a72e8e843d-a72e8e843d.woff  generic-icons-bd0221511d.ttf             generic-icons.woff
```

Au bout d'un certain temps, le build ne fonctionne plus car les noms de fichiers sont trop longs:
```
./build.sh buildLocalFront
[...]
Error: ENAMETOOLONG: name too long, open '/home/node/app/assets/themes/generic-icons/fonts/generic-icons-a72e8e843d-a72e8e843d-a72e8e843d-a72e8e843d-a72e8e843d-a72e8e843d-a72e8e843d-a72e8e843d-a72e8e843d-a72e8e843d-a72e8e843d-a72e8e843d-a72e8e843d-a72e8e843d-a72e8e843d-a72e8e843d-a72e8e843d-a72e8e843d-a72e8e843d-a72e8e843d-a72e8e843d-a72e8e843d.woff'
   at Error (native)
```

La PR propose de restreindre la liste des fichiers de fonts auquels on veut ajouter un numéro de révision.