### PR TITLE
Add response CAS Pearltrees in template

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group=fr.wseduc
 archivesBaseName=springboard-plugin
-version=2.4.2
+version=2.4-SNAPSHOT

--- a/src/main/resources/ent-core.json.template
+++ b/src/main/resources/ent-core.json.template
@@ -614,6 +614,11 @@
             "patterns" : []
           },
           {
+            "class" : "org.entcore.cas.services.PearltreesRegisteredService",
+            "principalAttributeName" : "login",
+            "patterns" : []
+          },
+          {
             "class" : "org.entcore.cas.services.DefaultRegisteredService",
             "principalAttributeName" : "login",
             "patterns" : [${patternDefaultRegisteredService}]

--- a/src/main/resources/ent-core.json.template
+++ b/src/main/resources/ent-core.json.template
@@ -47,7 +47,7 @@
   }
 },
 {
-  "name": "fr.wseduc~mod-zip~2.0.1",
+  "name": "fr.wseduc~mod-zip~2.0.2",
   "waitDeploy" : true,
   "worker": true,
   "config":{
@@ -120,6 +120,7 @@
     "address" : "entcore.pdf.generator"
   }
 },
+
 { "name": "org.entcore~infra~${entcoreVersion}",
 "waitDeploy" : true,
 "config" : {
@@ -182,7 +183,6 @@
       "legacy-indexes" : [{ "for" : "node", "name" : "node_auto_index", "type" : "fulltext" }]
     }
   }},
-
   {
     "name": "org.entcore~app-registry~${entcoreVersion}",
     "waitDeploy" : true,


### PR DESCRIPTION
Ajout de la réponse CAS de Pearltrees dans la configuration du springboard.

Lié à : https://github.com/opendigitaleducation/entcore/pull/187