### PR TITLE
feat : Add response CAS Explorateur de Metiers in template

### DIFF
--- a/src/main/resources/ent-core.json.template
+++ b/src/main/resources/ent-core.json.template
@@ -620,6 +620,11 @@
             "patterns" : []
           },
           {
+            "class" : "org.entcore.cas.services.ExplorateurDeMetiersRegisteredService",
+            "principalAttributeName" : "id",
+            "patterns" : []
+          },
+          {
             "class" : "org.entcore.cas.services.DefaultRegisteredService",
             "principalAttributeName" : "login",
             "patterns" : [${patternDefaultRegisteredService}]


### PR DESCRIPTION
Ajout de la réponse CAS de Explorateur de Metiers dans la configuration du springboard.

Lié à : https://github.com/opendigitaleducation/entcore/pull/194