### PR TITLE
[ODE] fix: allow generateConf to work outisde of Docker

### DIFF
--- a/src/main/groovy/fr/wseduc/gradle/springboard/FileUtils.groovy
+++ b/src/main/groovy/fr/wseduc/gradle/springboard/FileUtils.groovy
@@ -7,7 +7,9 @@ class FileUtils {
 
 	static def createFile(String propertiesFile, String templateFileName, String outputFileName) {
 		def props = new Properties()
-		props.load(new FileInputStream(new File(propertiesFile)))
+		def file = new File(propertiesFile)
+		def rootDirectory = file.getParentFile()
+		props.load(new FileInputStream(file))
 		def bindings = [:]
 		props.propertyNames().each{prop->
 			if ("assetsPath".equals(prop) &&  !props.getProperty(prop).startsWith(File.separator)) {
@@ -17,7 +19,7 @@ class FileUtils {
 			}
 		}
 		def defaultProps = new Properties()
-		defaultProps.load(new FileInputStream(new File("default.properties")))
+		defaultProps.load(new FileInputStream(new File(rootDirectory, "default.properties")))
 		defaultProps.propertyNames().each { prop ->
 			if (!bindings.containsKey(prop)) {
 				bindings[prop] = defaultProps.getProperty(prop)

--- a/src/main/groovy/fr/wseduc/gradle/springboard/SpringboardPlugin.groovy
+++ b/src/main/groovy/fr/wseduc/gradle/springboard/SpringboardPlugin.groovy
@@ -10,7 +10,8 @@ class SpringboardPlugin implements Plugin<Project> {
 	@Override
 	void apply(Project project) {
 		project.task("generateConf") << {
-			FileUtils.createFile("conf.properties", "ent-core.json.template", "ent-core.json")
+			def rootDir = project.getRootDir().getAbsolutePath()
+			FileUtils.createFile("${rootDir}/conf.properties", "${rootDir}/ent-core.json.template", "${rootDir}/ent-core.json")
 		}
 
 		project.task("extractDeployments") << {

--- a/src/main/resources/docker-compose.yml
+++ b/src/main/resources/docker-compose.yml
@@ -1,5 +1,5 @@
 vertx:
-  image: opendigitaleducation/vertx-service-launcher:1.4.0
+  image: opendigitaleducation/vertx-service-launcher:1.4.2
   user: "1000:1000"
   ports:
     - "8090:8090"
@@ -31,7 +31,7 @@ neo4j:
     - ./neo4j-conf:/conf
 
 elasticsearch:
-  image: opensearchproject/opensearch:1.0.0
+  image: opensearchproject/opensearch:2.4.1
   environment:
     ES_JAVA_OPTS: "-Xms1g -Xmx1g"
     MEM_LIMIT: 1073741824
@@ -51,7 +51,7 @@ elasticsearch:
     - "9300:9300"
 
 postgres:
-  image: postgres:9.5
+  image: postgres:14.3
   environment:
     POSTGRES_PASSWORD: We_1234
     POSTGRES_USER: web-education

--- a/src/main/resources/ent-core.json.template
+++ b/src/main/resources/ent-core.json.template
@@ -2,7 +2,7 @@
   "assets-path": "${assetsPath}",
 "services" : [
 {
-  "name": "io.vertx~mod-mongo-persistor~3.2-SNAPSHOT",
+  "name": "io.vertx~mod-mongo-persistor~3.2.0",
   "waitDeploy" : true,
   "worker": true,
   "multi-threaded": true,
@@ -55,7 +55,7 @@
   }
 },
 {
-  "name": "fr.wseduc~mod-postgresql~1.2.0",
+  "name": "fr.wseduc~mod-postgresql~1.3.1",
   "waitDeploy" : true,
   "worker": true,
   "multi-threaded" : true,
@@ -68,7 +68,7 @@
 },
 <% if (pgAdminUser != null && !pgAdminUser.trim().isEmpty()) { %>
 {
-  "name": "fr.wseduc~mod-postgresql~1.2.0",
+  "name": "fr.wseduc~mod-postgresql~1.3.1",
   "waitDeploy" : true,
   "worker": true,
   "multi-threaded" : true,
@@ -118,7 +118,7 @@
   },
 <% } %>
 {
-  "name": "fr.wseduc~mod-sms-proxy~1.0.2",
+  "name": "fr.wseduc~mod-sms-proxy~1.1-SNAPSHOT",
   "waitDeploy" : true,
   "worker": true,
   "config":{


### PR DESCRIPTION
# Description

When used outside of Docker, the task generateConf failed because the full path of the conf files were not specified so it defaulted to gradle installation dir. Now, we use the rootDir path of the project.

Upgrade versions of different modules.